### PR TITLE
add event modal component

### DIFF
--- a/src/components/Carousel/Carousel.jsx
+++ b/src/components/Carousel/Carousel.jsx
@@ -40,10 +40,22 @@ const Carousel = ({ slides }) => {
       onFocus={handleFocusEnter}
       onMouseLeave={handleFocusExit}
     >
-      {/* <div className="left arrow" onClick={goToPrevSlide}>
+      {/* <div
+        className="left arrow"
+        onClick={goToPrevSlide}
+        onKeyDown={goToPrevSlide}
+        role="button"
+        tabIndex={0}
+      >
         ❰
       </div>
-      <div className="right arrow" onClick={goToNextSlide}>
+      <div
+        className="right arrow"
+        onClick={goToNextSlide}
+        onKeyDown={goToNextSlide}
+        role="button"
+        tabIndex={0}
+      >
         ❱
       </div> */}
       <div
@@ -72,7 +84,8 @@ const Carousel = ({ slides }) => {
               onKeyDown={() => {
                 setCurrentIndex(slideIndex);
               }}
-              role="presentation"
+              role="button"
+              tabIndex={0}
             >
               •
             </div>

--- a/src/components/EventModal/EventModal.jsx
+++ b/src/components/EventModal/EventModal.jsx
@@ -1,0 +1,88 @@
+import './index.less';
+import { IoMdClose } from 'react-icons/io';
+
+const EventModal = ({
+  isOpen,
+  toggleModal,
+  header,
+  location,
+  sublocation,
+  date,
+  times,
+  cohosts,
+  tagIcon,
+  tagText,
+  children,
+}) => {
+  if (!isOpen) return null;
+  const dateStr = new Date(date).toLocaleDateString('en-GB', {
+    weekday: 'short',
+    day: 'numeric',
+    month: 'short',
+    year: 'numeric',
+  });
+  return (
+    <div className="overlay" onClick={toggleModal}>
+      <div
+        className="modal-container"
+        onClick={(e) => {
+          e.stopPropagation();
+        }}
+      >
+        <div className="close-btn" onClick={toggleModal}>
+          <IoMdClose />
+        </div>
+        <div className="tag">
+          <div className="tag-icon">{tagIcon}</div>
+          <div className="tag-text">{tagText}</div>
+        </div>
+        <div className="modal-header">{header}</div>
+        <div className="modal-description">
+          <div className="modal-location">{`${location}, ${sublocation}`}</div>
+          <div className="modal-datetime">{`${dateStr}, ${times}`}</div>
+          <div className="modal-cohosts">{`with ${cohosts}`}</div>
+        </div>
+        <div className="modal-body">{children}</div>
+      </div>
+    </div>
+  );
+};
+export default EventModal;
+
+{
+  /* <button
+  type="button"
+  className="btn btn-primary"
+  onClick={() => {
+    toggleModal();
+  }}
+>
+  Click me
+</button>
+<EventModal
+  isOpen={isOpen}
+  toggleModal={toggleModal}
+  header="QuantSoc x Pisoc Options Trading Workshop"
+  location="UNSW"
+  sublocation="Mathews 104"
+  date={new Date().toISOString()}
+  times="5:00pm - 7:00pm"
+  cohosts="Pisoc"
+  tagIcon={<LiaChalkboardTeacherSolid size={30} />}
+  tagText="Workshop"
+>
+  <img />
+  <p>
+    Are YOU a student interested in what options trading is? Do YOU want
+    to know how to make money with your skills? Quantsoc is partnering up
+    with the Personal Investment Society to bring you our Options Trading
+    Workshop!
+  </p>
+  <p>
+    Come bring yourself and all your friends to QuantSoc x Pisoc&apos;s
+    Options Trading workshop on Wednesday, 14th of June 5:00pm to 7:00pm
+    at Mathews 104! This workshop is open to people with ALL levels of
+    knowledge.
+  </p>
+</EventModal> */
+}

--- a/src/components/EventModal/EventModal.jsx
+++ b/src/components/EventModal/EventModal.jsx
@@ -22,14 +22,21 @@ const EventModal = ({
     year: 'numeric',
   });
   return (
-    <div className="overlay" onClick={toggleModal}>
+    <div className="overlay" onClick={toggleModal} role="presentation">
       <div
         className="modal-container"
         onClick={(e) => {
           e.stopPropagation();
         }}
+        role="presentation"
       >
-        <div className="close-btn" onClick={toggleModal}>
+        <div
+          role="button"
+          className="close-btn"
+          onClick={toggleModal}
+          onKeyDown={toggleModal}
+          tabIndex={0}
+        >
           <IoMdClose />
         </div>
         <div className="tag">
@@ -49,40 +56,48 @@ const EventModal = ({
 };
 export default EventModal;
 
-{
-  /* <button
-  type="button"
-  className="btn btn-primary"
-  onClick={() => {
-    toggleModal();
-  }}
->
-  Click me
-</button>
-<EventModal
-  isOpen={isOpen}
-  toggleModal={toggleModal}
-  header="QuantSoc x Pisoc Options Trading Workshop"
-  location="UNSW"
-  sublocation="Mathews 104"
-  date={new Date().toISOString()}
-  times="5:00pm - 7:00pm"
-  cohosts="Pisoc"
-  tagIcon={<LiaChalkboardTeacherSolid size={30} />}
-  tagText="Workshop"
->
-  <img />
-  <p>
-    Are YOU a student interested in what options trading is? Do YOU want
-    to know how to make money with your skills? Quantsoc is partnering up
-    with the Personal Investment Society to bring you our Options Trading
-    Workshop!
-  </p>
-  <p>
-    Come bring yourself and all your friends to QuantSoc x Pisoc&apos;s
-    Options Trading workshop on Wednesday, 14th of June 5:00pm to 7:00pm
-    at Mathews 104! This workshop is open to people with ALL levels of
-    knowledge.
-  </p>
-</EventModal> */
-}
+/*
+import useModal from 'hooks/useModal';
+import EventModal from 'components/EventModal';
+...
+
+  const { isOpen, toggleModal } = useModal();
+  return (
+    <>
+      <button
+        type="button"
+        className="btn btn-primary"
+        onClick={() => {
+          toggleModal();
+        }}
+      >
+        Click me
+      </button>
+      <EventModal
+        isOpen={isOpen}
+        toggleModal={toggleModal}
+        header="QuantSoc x Pisoc Options Trading Workshop"
+        location="UNSW"
+        sublocation="Mathews 104"
+        date={new Date().toISOString()}
+        times="5:00pm - 7:00pm"
+        cohosts="Pisoc"
+        tagIcon={IoMdClose size={30} />}
+        tagText="Workshop"
+      >
+        <p>
+          Are YOU a student interested in what options trading is? Do YOU want
+          to know how to make money with your skills? Quantsoc is partnering up
+          with the Personal Investment Society to bring you our Options Trading
+          Workshop!
+        </p>
+        <p>
+          Come bring yourself and all your friends to QuantSoc x Pisoc&apos;s
+          Options Trading workshop on Wednesday, 14th of June 5:00pm to 7:00pm
+          at Mathews 104! This workshop is open to people with ALL levels of
+          knowledge.
+        </p>
+      </EventModal>
+    </>
+  );
+*/

--- a/src/components/EventModal/index.js
+++ b/src/components/EventModal/index.js
@@ -1,0 +1,3 @@
+import EventModal from './EventModal';
+
+export default EventModal;

--- a/src/components/EventModal/index.less
+++ b/src/components/EventModal/index.less
@@ -1,0 +1,83 @@
+@import 'styles/constants.less';
+
+.overlay {
+  background-color: #41414188;
+  position: fixed;
+  width: 100%;
+  height: 100%;
+  top: 0;
+  left: 0;
+}
+
+.modal-container {
+  min-height: 500px;
+  min-width: 800px;
+  flex-shrink: 0;
+  position: fixed;
+  border-radius: 10px;
+  top: 30%;
+  left: 50%;
+  transform: translate(-50%, 0%);
+  background-color: #fff;
+  padding: 1.75rem 2.5rem;
+}
+
+.close-btn {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  cursor: pointer;
+}
+
+.tag {
+  display: flex;
+  color: @quantsoc-accent;
+  .tag-icon {
+    margin-right: 0.5rem;
+  }
+
+  .tag-text {
+    font-family: Poppins;
+    font-size: 20px;
+  }
+}
+
+.modal-header {
+  font-family: Poppins;
+  font-size: 32px;
+  font-weight: 500;
+}
+
+.modal-description {
+  color: @text-secondary;
+  font-family: Poppins;
+  font-size: 16px;
+  margin: 0.5rem 0;
+  * {
+    margin: 0.2rem 0;
+  }
+}
+
+.modal-body {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+
+  p {
+    font-size: 16px;
+    font-weight: 300;
+    margin: 0.5rem 0;
+  }
+}
+
+@media screen and (max-width: 1200px) {
+  .modal-container {
+    min-width: 600px;
+  }
+}
+@media screen and (max-width: 900px) {
+  .modal-container {
+    min-width: 400px;
+    padding: 1rem 2rem;
+  }
+}

--- a/src/components/QuantSocLogo/QuantSocLogo.jsx
+++ b/src/components/QuantSocLogo/QuantSocLogo.jsx
@@ -13,7 +13,8 @@ const QuantSocLogo = () => {
       className="logo"
       onClick={handleClick}
       onKeyDown={handleClick}
-      role="presentation"
+      role="button"
+      tabIndex={0}
     >
       <img src={logo} alt="logo" className="logo-img" />
       <h2 className="logo-title">QuantSoc</h2>

--- a/src/hooks/useModal.jsx
+++ b/src/hooks/useModal.jsx
@@ -1,0 +1,16 @@
+import { useState } from 'react';
+
+const useModal = () => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const toggleModal = () => {
+    setIsOpen(!isOpen);
+  };
+
+  return {
+    isOpen,
+    toggleModal,
+  };
+};
+
+export default useModal;


### PR DESCRIPTION
This PR adds an event modal component that takes in the following props:
- event title (header)
- location
- sublocation
- date
- times (start to end)
- cohosts
- tag icon
- tag text
- modal body html elements to display after the metadata.

I've also added correct ARIA conforming props to improve accessibility.