### PR TITLE
Fix mobile responsiveness sizing of event card carousel 

### DIFF
--- a/src/components/Carousel/index.less
+++ b/src/components/Carousel/index.less
@@ -67,9 +67,3 @@
 .selected {
   color: #333;
 }
-
-@media screen and (max-width: 450px) {
-  .arrow {
-    display: none;
-  }
-}

--- a/src/components/EventCard/index.less
+++ b/src/components/EventCard/index.less
@@ -64,8 +64,20 @@
   transform: scale(1);
 }
 
-@media (max-width: 400px) {
+@media screen and (max-width: @mobile) {
   .event-card__container {
-    width: 100%;
+    width: 245px;
+    height: 315px;
+  }
+  .event-card__header {
+    font-size: 0.8rem;
+  }
+  .event-card__image {
+    height: 100px;
+  }
+  .event-card__button {
+    button {
+      font-size: 0.7rem;
+    }
   }
 }

--- a/src/components/EventDesc/index.less
+++ b/src/components/EventDesc/index.less
@@ -10,7 +10,6 @@
   display: flex;
   align-items: center;
   margin: 0.5rem 0;
-  font-size: 0.8rem;
 }
 
 .event-desc > p {
@@ -38,4 +37,10 @@
 
 .urgent {
   color: @quantsoc-red;
+}
+
+@media screen and (max-width: @mobile) {
+  .event-desc p {
+    font-size: 0.8rem;
+  }
 }

--- a/src/components/EventTag/index.less
+++ b/src/components/EventTag/index.less
@@ -17,3 +17,16 @@
   font-size: 0.9rem;
   font-weight: 300;
 }
+
+@media screen and (max-width: @mobile) {
+  .event-tag {
+    margin-bottom: 0.5rem;
+  }
+  .event-tag__icon {
+    width: 1rem;
+    height: 1rem;
+  }
+  .event-tag__text {
+    font-size: 0.7rem;
+  }
+}

--- a/src/components/RedirectButton/index.less
+++ b/src/components/RedirectButton/index.less
@@ -21,3 +21,10 @@
     background-color: @quantsoc-accent-light;
   }
 }
+
+@media screen and (max-width: @mobile) {
+  .redirect-button {
+    font-size: 0.8rem;
+    height: 35px;
+  }
+}

--- a/src/components/SocialsButton/index.less
+++ b/src/components/SocialsButton/index.less
@@ -31,3 +31,15 @@
   color: white;
   margin: 0 6px;
 }
+
+@media screen and (max-width: @mobile) {
+  .socials-button-container {
+    height: 35px;
+  }
+  .socials-button-text {
+    font-size: 0.8rem;
+  }
+  .socials-button-icon {
+    font-size: 16px;
+  }
+}

--- a/src/components/Sponsor/index.less
+++ b/src/components/Sponsor/index.less
@@ -1,3 +1,5 @@
+@import 'styles/constants.less';
+
 .sponsor__container {
   flex: 1 0 33%; /* explanation below */
   display: flex;
@@ -9,4 +11,10 @@
 }
 .sponsor__container img:hover {
   transform: scale(1.1);
+}
+
+@media screen and (max-width: @mobile) {
+  .sponsor__container img {
+    max-width: 200px;
+  }
 }

--- a/src/styles/constants.less
+++ b/src/styles/constants.less
@@ -14,5 +14,5 @@
 @quantsoc-red: #ff6565;
 
 // media query dimensions
-@mobile: 400px;
+@mobile: 475px;
 @tablet: 1170px;

--- a/src/styles/index.less
+++ b/src/styles/index.less
@@ -152,4 +152,7 @@ code {
   p {
     font-size: 16px;
   }
+  section {
+    padding: 0 0.75rem;
+  }
 }


### PR DESCRIPTION
This PR fixes the mobile responsiveness sizing of the event card carousels by reducing the font and image sizes on the cards to accommodate for smaller dimensions. This allows the carousel arrow to be re-enabled. 
- also reduced the font sizes and dimensions of buttons and sponsor logos