### PR TITLE
Fix redirect button spacing

### DIFF
--- a/src/components/RedirectButton/index.less
+++ b/src/components/RedirectButton/index.less
@@ -24,6 +24,7 @@
 
 @media screen and (max-width: @mobile) {
   .redirect-button {
+    color: #000;  // ios defaults to blue text
     font-size: 0.8rem;
     height: 35px;
   }

--- a/src/components/RedirectButton/index.less
+++ b/src/components/RedirectButton/index.less
@@ -8,7 +8,7 @@
   box-sizing: border-box;
   display: inline-block;
   width: fit-content;
-  min-width: 100px;
+  min-width: 120px;
   height: 45px;
   text-wrap: nowrap;
   cursor: pointer;

--- a/src/components/RedirectButton/index.less
+++ b/src/components/RedirectButton/index.less
@@ -24,7 +24,6 @@
 
 @media screen and (max-width: @mobile) {
   .redirect-button {
-    color: #000;
     font-size: 0.8rem;
     height: 35px;
   }

--- a/src/components/RedirectButton/index.less
+++ b/src/components/RedirectButton/index.less
@@ -24,6 +24,7 @@
 
 @media screen and (max-width: @mobile) {
   .redirect-button {
+    color: #000;
     font-size: 0.8rem;
     height: 35px;
   }


### PR DESCRIPTION
<img width="390" alt="Screen Shot 2023-12-11 at 12 27 13 pm" src="https://github.com/QuantSoc/website/assets/86920949/8abc964a-b986-4c54-860f-8e1a53467072">

- extended button width to avoid this^^
- explicitly set colour to black since ios defaults to blue text