### PR TITLE
fix: prevent overlapping of carousel slides in Safari for landing page hero section.

### DIFF
--- a/src/routes/LandingPage/HeroSection/EventSlide.jsx
+++ b/src/routes/LandingPage/HeroSection/EventSlide.jsx
@@ -13,7 +13,7 @@ const EventSlide = ({ hideRedirect = false }) => {
         />
       </div>
       <div className="hero-item stack">
-        <h1 className="hero-heading">Upcoming Events at QuantSoc</h1>
+        <h1>Upcoming Events at QuantSoc</h1>
         <p className="text-body">
           Join us for exciting events, competitions and gatherings. Whether
           you&apos;ve a budding interest or a deeper passion, discover the world

--- a/src/routes/LandingPage/HeroSection/index.less
+++ b/src/routes/LandingPage/HeroSection/index.less
@@ -4,15 +4,12 @@
   justify-content: space-between;
   white-space: wrap;
 
-  .hero-heading {
-    width: 75%;
-  }
-
   .hero-item {
     display: flex;
     justify-content: center;
     width: 50%;
     padding: 1rem 0rem;
+    white-space: normal;
 
     h1 {
       margin-bottom: 1.5rem;


### PR DESCRIPTION
Before:
<img width="1254" alt="Screen Shot 2023-12-13 at 4 32 12 pm" src="https://github.com/QuantSoc/website/assets/86920949/ff57fc4a-5c79-418b-9e6e-5f30ff0850d0">

After:
<img width="1210" alt="Screen Shot 2023-12-13 at 6 03 50 pm" src="https://github.com/QuantSoc/website/assets/86920949/43c0975a-d8b7-4208-8d60-9c663d81771c">
