### PR TITLE
Add mobile swipe touch support for carousel  

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -18,7 +18,6 @@
 			]
 		}
 	},
-	"appPort": ["5173:3000"],
 	// Features to add to the dev container. More info: https://containers.dev/features.
 	// "features": {},
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -18,7 +18,7 @@
 			]
 		}
 	},
-
+	"appPort": ["5173:3000"],
 	// Features to add to the dev container. More info: https://containers.dev/features.
 	// "features": {},
 

--- a/src/components/BurgerMenu/BurgerMenu.jsx
+++ b/src/components/BurgerMenu/BurgerMenu.jsx
@@ -1,18 +1,44 @@
-import React from 'react';
+import React, { useState, useRef, useEffect } from 'react';
 import './index.less';
 import { useNavigate } from 'react-router-dom';
 import logo from '../../assets/logo-quantsoc.svg';
 
 const BurgerMenu = () => {
   const navigate = useNavigate();
+  const [isChecked, setIsChecked] = useState(false);
+  const menuRef = useRef(null);
+
+  useEffect(() => {
+    const handleClickOutside = (event) => {
+      if (menuRef.current && !menuRef.current.contains(event.target)) {
+        setIsChecked(false);
+      }
+    };
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, [menuRef]);
+
+  const handleLinkClick = (link) => {
+    navigate(link);
+    setIsChecked(false);
+  };
   return (
     <div className="hamburger-menu">
-      <input id="menu-toggle" type="checkbox" />
+      <input
+        id="menu-toggle"
+        type="checkbox"
+        checked={isChecked}
+        onChange={() => {
+          setIsChecked(!isChecked);
+        }}
+      />
       <div className="menu-btn">
         <span />
       </div>
 
-      <div className="menu-vertical">
+      <div className="menu-vertical" ref={menuRef}>
         <img
           src={logo}
           alt="QuantSoc's logo within burger menu"
@@ -25,7 +51,7 @@ const BurgerMenu = () => {
           onKeyDown={() => {}}
           tabIndex={-1}
           onClick={() => {
-            navigate('/');
+            handleLinkClick('/');
           }}
         >
           Home
@@ -36,7 +62,7 @@ const BurgerMenu = () => {
           onKeyDown={() => {}}
           tabIndex={-1}
           onClick={() => {
-            navigate('/about');
+            handleLinkClick('/about');
           }}
         >
           About Us
@@ -47,7 +73,7 @@ const BurgerMenu = () => {
           onKeyDown={() => {}}
           tabIndex={-1}
           onClick={() => {
-            navigate('/events');
+            handleLinkClick('/events');
           }}
         >
           Events
@@ -58,7 +84,7 @@ const BurgerMenu = () => {
           onKeyDown={() => {}}
           tabIndex={-1}
           onClick={() => {
-            navigate('/resources');
+            handleLinkClick('/resources');
           }}
         >
           Resources
@@ -69,7 +95,7 @@ const BurgerMenu = () => {
           onKeyDown={() => {}}
           tabIndex={-1}
           onClick={() => {
-            navigate('/sponsors');
+            handleLinkClick('/sponsors');
           }}
         >
           Sponsors

--- a/src/components/BurgerMenu/index.less
+++ b/src/components/BurgerMenu/index.less
@@ -7,13 +7,13 @@
 }
 
 #menu-toggle {
-  width: 20px;
-  height: 20px;
+  width: 15px;
+  height: 15px;
   position: absolute;
   z-index: 4;
   opacity: 0;
-  top: 0.75rem;
-  right: 2rem;
+  top: 1rem;
+  right: 2.15rem;
   cursor: pointer;
 }
 #menu-toggle:checked + .menu-btn > span {
@@ -30,14 +30,18 @@
 #menu-toggle:checked ~ .menu-vertical {
   right: 0 !important;
 }
+#menu-toggle:checked ~ .menu-btn {
+  z-index: 5;
+}
 .menu-btn {
   position: absolute;
-  top: 2rem;
+  top: 1.5rem;
   right: calc(2rem + 3px);
   margin-top: -10px;
   width: 20px;
   height: 20px;
   z-index: 3;
+  cursor: pointer;
 }
 #menu-toggle:checked {
   position: fixed;
@@ -50,6 +54,7 @@
 .menu-btn > span::after {
   display: block;
   position: absolute;
+  top: 50%;
   width: 100%;
   height: 1px;
   background-color: #212121;

--- a/src/components/Carousel/Carousel.jsx
+++ b/src/components/Carousel/Carousel.jsx
@@ -1,9 +1,11 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useRef } from 'react';
 import './index.less';
 
 const Carousel = ({ slides, hideArrows = false }) => {
   const [currentIndex, setCurrentIndex] = useState(0);
   const [isHovering, setIsHovering] = useState(false);
+  const touchStartX = useRef(null);
+
   const goToPrevSlide = () => {
     setCurrentIndex((prevIndex) => {
       return prevIndex === 0 ? slides.length - 1 : prevIndex - 1;
@@ -13,6 +15,20 @@ const Carousel = ({ slides, hideArrows = false }) => {
     setCurrentIndex((prevIndex) => {
       return prevIndex === slides.length - 1 ? 0 : prevIndex + 1;
     });
+  };
+
+  const handleTouchStart = (e) => {
+    touchStartX.current = e.touches[0].clientX;
+  };
+  
+  const handleTouchMove = (e) => {
+    if (touchStartX.current === null) return;
+    
+    const deltaX = e.touches[0].clientX - touchStartX.current;
+    console.log(deltaX)
+
+    deltaX > 7 ? goToPrevSlide() : deltaX < -7 ? goToNextSlide() : null;
+    touchStartX.current = null;
   };
 
   useEffect(() => {
@@ -43,7 +59,7 @@ const Carousel = ({ slides, hideArrows = false }) => {
       onMouseOver={handleFocusEnter}
       onFocus={handleFocusEnter}
       onMouseLeave={handleFocusExit}
-    >
+      >
       {!hideArrows && (
         <div
           className="left arrow"
@@ -69,6 +85,8 @@ const Carousel = ({ slides, hideArrows = false }) => {
       <div
         className="inner"
         style={{ transform: `translate(-${currentIndex * 100}%)` }}
+        onTouchStart={handleTouchStart}
+        onTouchMove={handleTouchMove}
       >
         {slides.map((slide) => {
           return (

--- a/src/components/Carousel/Carousel.jsx
+++ b/src/components/Carousel/Carousel.jsx
@@ -20,20 +20,20 @@ const Carousel = ({ slides, hideArrows = false }) => {
   const handleTouchStart = (e) => {
     touchStartX.current = e.touches[0].clientX;
   };
-  
+
   const handleTouchMove = (e) => {
     if (touchStartX.current === null) return;
-    
-    const deltaX = e.touches[0].clientX - touchStartX.current;
-    console.log(deltaX)
 
-    deltaX > 7 ? goToPrevSlide() : deltaX < -7 ? goToNextSlide() : null;
+    const deltaX = e.touches[0].clientX - touchStartX.current;
+
+    if (deltaX > 7) goToPrevSlide();
+    if (deltaX < -7) goToNextSlide();
     touchStartX.current = null;
   };
 
   useEffect(() => {
     setCurrentIndex(0);
-  }, [slides]);
+  }, [slides.length]);
 
   useEffect(() => {
     const interval = setInterval(() => {
@@ -59,7 +59,7 @@ const Carousel = ({ slides, hideArrows = false }) => {
       onMouseOver={handleFocusEnter}
       onFocus={handleFocusEnter}
       onMouseLeave={handleFocusExit}
-      >
+    >
       {!hideArrows && (
         <div
           className="left arrow"

--- a/src/components/EventCard/EventCard.jsx
+++ b/src/components/EventCard/EventCard.jsx
@@ -18,6 +18,9 @@ const EventCard = ({
   image,
   tagType,
 }) => {
+  const handleImageError = (event) => {
+    event.target.src = placeholder;
+  };
   return (
     <div className="event-card__container">
       <EventTag tagType={tagType} />
@@ -34,6 +37,7 @@ const EventCard = ({
         className="event-card__image"
         src={image !== '' ? image : placeholder}
         alt={header}
+        onError={handleImageError}
       />
       <div className="event-card__button">
         <BiExpandVertical />

--- a/src/components/EventCard/EventCard.jsx
+++ b/src/components/EventCard/EventCard.jsx
@@ -18,9 +18,6 @@ const EventCard = ({
   image,
   tagType,
 }) => {
-  const handleImageError = (event) => {
-    event.target.src = placeholder;
-  };
   return (
     <div className="event-card__container">
       <EventTag tagType={tagType} />
@@ -37,7 +34,9 @@ const EventCard = ({
         className="event-card__image"
         src={image !== '' ? image : placeholder}
         alt={header}
-        onError={handleImageError}
+        onError={(e) => {
+          e.target.src = placeholder;
+        }}
       />
       <div className="event-card__button">
         <BiExpandVertical />

--- a/src/components/EventModal/EventModal.jsx
+++ b/src/components/EventModal/EventModal.jsx
@@ -74,6 +74,9 @@ const EventModal = ({
             className="event-modal__image"
             src={image !== '' ? image : placeholder}
             alt={header}
+            onError={(e) => {
+              e.target.src = placeholder;
+            }}
           />
           {children}
         </div>


### PR DESCRIPTION
This PR adds support for slide/swipe actions on Carousels on mobile.
Additional changes include:
- fix the EventCarousel bug that reset the slide index to zero whenever an EventModal opens by querying changes in the number of slides given
- add image load error placeholders for issues loading image URLs
- add more useable burger menu click-away action handling for a smoother experience 