### PR TITLE
Fix/no ref/event carousel functionality with no events

### DIFF
--- a/src/components/EventsCarousel/EventsCarousel.jsx
+++ b/src/components/EventsCarousel/EventsCarousel.jsx
@@ -74,33 +74,46 @@ const EventsCarousel = ({ eventsFilterCondition }) => {
     }
     return eventSlides;
   };
+
   return (
-    <>
-      <Carousel slides={createEventSlides()} />
-      <EventModal
-        isOpen={isOpen}
-        toggleModal={toggleModal}
-        header={events[eventIndex].header}
-        location={events[eventIndex].location}
-        sublocation={events[eventIndex].sublocation}
-        startDate={events[eventIndex].startDate}
-        endDate={events[eventIndex].endDate}
-        tagType={events[eventIndex].tagType}
-        image={events[eventIndex].image}
-        times={events[eventIndex].times}
-        cohosts={events[eventIndex].cohosts}
-        link={events[eventIndex].link}
-        tagIcon={events[eventIndex].tagIcon}
-      >
-        {events[eventIndex].body.split('\n').map((paragraph) => {
-          return (
-            <p key={`event-modal-body-${paragraph.slice(0, 10)}`}>
-              {paragraph}
-            </p>
-          );
-        })}
-      </EventModal>
-    </>
+    <div className="event-carousel-section">
+      {
+        events.length > 0
+          ? (
+            <div>
+              <Carousel slides={createEventSlides()} />
+              <EventModal
+                isOpen={isOpen}
+                toggleModal={toggleModal}
+                header={events[eventIndex].header}
+                location={events[eventIndex].location}
+                sublocation={events[eventIndex].sublocation}
+                startDate={events[eventIndex].startDate}
+                endDate={events[eventIndex].endDate}
+                tagType={events[eventIndex].tagType}
+                image={events[eventIndex].image}
+                times={events[eventIndex].times}
+                cohosts={events[eventIndex].cohosts}
+                link={events[eventIndex].link}
+                tagIcon={events[eventIndex].tagIcon}
+              >
+                {events[eventIndex].body.split('\n').map((paragraph) => {
+                  return (
+                    <p key={`event-modal-body-${paragraph.slice(0, 10)}`}>
+                      {paragraph}
+                    </p>
+                  );
+                })}
+              </EventModal>
+            </div>
+          )
+          : (
+            <div className="no-events-text">
+              There are no upcoming events at this time.
+            </div>
+          )
+      }
+    </div>
   );
 };
 export default EventsCarousel;

--- a/src/components/EventsCarousel/index.less
+++ b/src/components/EventsCarousel/index.less
@@ -8,6 +8,18 @@
   align-items: center;
 }
 
+.event-carousel-section {
+  display: flex;
+}
+
+.no-events-text {
+  margin: auto;
+  padding: 10px 0;
+  font-family: 'Poppins';
+  font-weight: 300;
+  font-size: 0.8rem;
+}
+
 @media screen and (max-width: 1400px) {
   .event-carousel__slide {
     grid-template-columns: repeat(2, 1fr);

--- a/src/data/events.json
+++ b/src/data/events.json
@@ -38,21 +38,21 @@
     "image": "",
     "body": ""
   },
-{
-"tagType":"trading",
-"header":"SQT x QuantSoc Mock Trading",
-"showAsEvent":"true",
-"location":"USYD",
-"sublocation":"Thinkspace",
-"startDate":"22 February 2024",
-"endDate":"22 February 2024",
-"times":"3pm - 4:30pm",
-"cohosts":"Sydney Quant Traders",
-"image":"https://scontent-syd2-1.xx.fbcdn.net/v/t39.30808-6/424996539_376430275132555_4776359446449838475_n.jpg?_nc_cat=110&ccb=1-7&_nc_sid=d8d9c5&_nc_ohc=OWkAaQOrNn0AX-uwXOs&_nc_ht=scontent-syd2-1.xx&oh=00_AfD71tkn569yx5_h5GbAErbb8h8x0bFpoKqRn6XQCqnJGw&oe=65C200DA",
-"link":"https://www.facebook.com/events/792500642705260",
-"body":"SQT has joined forces with QuantSoc to bring you the first Mock Trading event of the semester 🚀🚀🚀\nClick GOING on FB to register!\n_________________________________________________________\nMOCK TRADING is an adrenaline-filled game of quick thinking and psychological discipline. 🧠🔥\nNo knowledge of finance or trading needed! Make bets with each other on the actual value of something in a 'market' like:\n🥇 What's the top eSports tournaments prize pool in history?\n💪 How many push-ups can Karl do in 2 minutes?\n👴 What's the average age of everyone who'll be attending mock trading?\nTake calculated risks and sophisticated trades to outsmart your competition. The player with the most profit at the end of the game is the WINNER! 👑\nBeginners welcome, we explain the rules before any game! Free food and drinks will be provided. 🍔\nRegister to play on the day 👉 https://quanttraders.club/"
-},
-{
+  {
+    "tagType": "trading",
+    "header": "SQT x QuantSoc Mock Trading",
+    "showAsEvent": true,
+    "location": "USYD",
+    "sublocation": "Thinkspace",
+    "startDate": "22 February 2024",
+    "endDate": "22 February 2024",
+    "times": "3pm - 4:30pm",
+    "cohosts": "Sydney Quant Traders",
+    "image": "https://scontent-syd2-1.xx.fbcdn.net/v/t39.30808-6/424996539_376430275132555_4776359446449838475_n.jpg?_nc_cat=110&ccb=1-7&_nc_sid=d8d9c5&_nc_ohc=OWkAaQOrNn0AX-uwXOs&_nc_ht=scontent-syd2-1.xx&oh=00_AfD71tkn569yx5_h5GbAErbb8h8x0bFpoKqRn6XQCqnJGw&oe=65C200DA",
+    "link": "https://www.facebook.com/events/792500642705260",
+    "body": "SQT has joined forces with QuantSoc to bring you the first Mock Trading event of the semester 🚀🚀🚀\nClick GOING on FB to register!\n_________________________________________________________\nMOCK TRADING is an adrenaline-filled game of quick thinking and psychological discipline. 🧠🔥\nNo knowledge of finance or trading needed! Make bets with each other on the actual value of something in a 'market' like:\n🥇 What's the top eSports tournaments prize pool in history?\n💪 How many push-ups can Karl do in 2 minutes?\n👴 What's the average age of everyone who'll be attending mock trading?\nTake calculated risks and sophisticated trades to outsmart your competition. The player with the most profit at the end of the game is the WINNER! 👑\nBeginners welcome, we explain the rules before any game! Free food and drinks will be provided. 🍔\nRegister to play on the day 👉 https://quanttraders.club/"
+  },
+  {
     "tagType": "opportunity",
     "header": "SIG Sydney Women's Discovery Days",
     "showAsEvent": false,

--- a/src/routes/LandingPage/ResourcesSection/index.less
+++ b/src/routes/LandingPage/ResourcesSection/index.less
@@ -7,6 +7,7 @@
 
   p {
     margin-bottom: 1.5rem;
+    align-self: flex-start;
   }
 
   .resources-buttons {


### PR DESCRIPTION
- Fixed issue where landing page and events page would be completely blank by adding functionality for when all events in events.json did not pass the events filter condition: 
        eventsFilterCondition={(event) => {
          return event.showAsEvent && new Date(event.endDate) >= new Date()
            ? event
            : null;
        }}
- Aligned resources section subtitle to flex-start (left) for design consistency.